### PR TITLE
WinRT and Game Console

### DIFF
--- a/include/Dynamic.h
+++ b/include/Dynamic.h
@@ -335,7 +335,7 @@ inline bool operator <= (bool inLHS,const Dynamic &inRHS) { return false; }
 inline bool operator >= (bool inLHS,const Dynamic &inRHS) { return false; }
 inline bool operator > (bool inLHS,const Dynamic &inRHS) { return false; }
 
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
 // Try to avoid the compiler using injected Box::operator int and Dynamic(null) when doing ==
 template<typename T>
 bool operator==(Platform::Box<T> ^inPtr, nullptr_t)

--- a/include/hx/HxcppMain.h
+++ b/include/hx/HxcppMain.h
@@ -35,7 +35,7 @@
       hxcpp_main();
    }
 
-#elif defined(HX_WINRT)
+#elif defined(HX_WINRT) && defined(__cplusplus_winrt)
 
    #include <Roapi.h>
    [ Platform::MTAThread ]

--- a/include/hx/Operators.h
+++ b/include/hx/Operators.h
@@ -117,7 +117,7 @@ inline L& UShrEq(L &inLHS, R inRHS) { inLHS = hx::UShr(inLHS,inRHS); return inLH
 template<typename L, typename R>
 inline L& ModEq(L &inLHS, R inRHS) { inLHS = DoubleMod(inLHS,inRHS); return inLHS; }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__SNC__)
 template<typename R>
 inline hx::FieldRef AddEq(hx::FieldRef inLHS, R inRHS) { inLHS = inLHS + inRHS; return inLHS; }
 template<typename R>
@@ -166,7 +166,7 @@ template<typename R>
 inline hx::IndexRef ModEq(hx::IndexRef inLHS, R inRHS) { inLHS = DoubleMod(inLHS,inRHS); return inLHS; }
 
 
-#endif // __GNUC__
+#endif // __GNUC__ || __SNC__
 
 
 template<typename T> inline T TCastObject(hx::Object *inObj) { return hx::BadCast(); }

--- a/include/hx/Thread.h
+++ b/include/hx/Thread.h
@@ -48,7 +48,7 @@ inline int HxAtomicInc(volatile int *ioWhere)
 inline int HxAtomicDec(volatile int *ioWhere)
    { return __atomic_dec(ioWhere); }
 
-#elif defined(HX_WINDOWS) && !defined(HX_WINRT) //winrt test
+#elif defined(HX_WINDOWS)
 
 inline bool HxAtomicExchangeIf(int inTest, int inNewVal,volatile int *ioWhere)
    { return InterlockedCompareExchange((volatile LONG *)ioWhere, inNewVal, inTest)==inTest; }

--- a/include/hxString.h
+++ b/include/hxString.h
@@ -38,7 +38,7 @@ public:
       *this = String([inString UTF8String]);
    }
    #endif
-   #ifdef HX_WINRT
+   #if defined(HX_WINRT) && defined(__cplusplus_winrt)
    inline String(Platform::String^ inString)
    {
       *this = String(inString->Data());

--- a/project/libs/std/Random.cpp
+++ b/project/libs/std/Random.cpp
@@ -61,17 +61,21 @@ static void rnd_set_seed( rnd *r, int s ) {
 
 static rnd *rnd_init( void *data ) {
 	rnd *r = (rnd*)data;
-   #ifdef HX_WINRT
+#if defined(NEKO_WINDOWS)
+  #if defined(HX_WINRT) && defined(__cplusplus_winrt)
 	int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
-   #elif defined(EPPC)
+  #else
+	int pid = GetCurrentProcessId();
+  #endif
+#elif defined(EPPC)
 	int pid = 1;
-   #else
+#else
 	int pid = getpid();
-   #endif
+#endif
 
 	unsigned int t;
 #ifdef HX_WINRT
-	t = clock();
+	t = (unsigned int)GetTickCount64();
 #elif defined(NEKO_WINDOWS)
 	t = GetTickCount();
 #elif defined(EPPC)

--- a/project/libs/std/Sys.cpp
+++ b/project/libs/std/Sys.cpp
@@ -15,7 +15,7 @@ int __sys_prims() { return 0; }
 #	include <windows.h>
 #	include <direct.h>
 #	include <conio.h>
-#       include <locale.h>
+#	include <locale.h>
 #else
 #	include <errno.h>
 #ifndef EPPC
@@ -46,9 +46,8 @@ int __sys_prims() { return 0; }
 #endif
 #endif
 
-#ifdef HX_WINRT
-#include <hx/Thread.h>
-#include <hx/Tls.h>
+#if defined(HX_WINRT) && !defined(_XBOX_ONE)
+#include <string>
 #endif
 
 #ifndef CLK_TCK
@@ -110,19 +109,10 @@ static value put_env( value e, value v ) {
 	<doc>Sleep a given number of seconds</doc>
 **/
 
-#ifdef HX_WINRT
-DECLARE_TLS_DATA(void,tlsSleepEvent)
-#endif
-
 static value sys_sleep( value f ) {
 	val_check(f,number);
 	gc_enter_blocking();
-#ifdef HX_WINRT
-   if (!tlsSleepEvent)
-      tlsSleepEvent = CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
-   WaitForSingleObjectEx(tlsSleepEvent, (int)(val_number(f)*1000), false);
-
-#elif defined(NEKO_WINDOWS)
+#if defined(NEKO_WINDOWS)
 	Sleep((DWORD)(val_number(f) * 1000));
 #elif defined(EPPC)
 //TODO: Implement sys_sleep for EPPC
@@ -533,8 +523,8 @@ static value sys_time() {
 	<doc>Return the most accurate CPU time spent since the process started (in seconds)</doc>
 **/
 static value sys_cpu_time() {
-#ifdef HX_WINRT
-   return alloc_float(0);
+#if defined(HX_WINRT) && !defined(_XBOX_ONE)
+    return alloc_float ((double)GetTickCount64()/1000.0);
 #elif defined(NEKO_WINDOWS)
 	FILETIME unused;
 	FILETIME stime;
@@ -543,7 +533,7 @@ static value sys_cpu_time() {
 		return alloc_null();
 	return alloc_float( ((double)(utime.dwHighDateTime+stime.dwHighDateTime)) * 65.536 * 6.5536 + (((double)utime.dwLowDateTime + (double)stime.dwLowDateTime) / 10000000) );
 #elif defined(EPPC)
-	return alloc_float ((double)(CLOCKS_PER_SEC * clock()));
+    return alloc_float ((double)clock()/(double)CLOCKS_PER_SEC);
 #else
 	struct tms t;
 	times(&t);
@@ -559,12 +549,11 @@ static value sys_read_dir( value p) {
 	val_check(p,string);
 
         value result = alloc_array(0);
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
    auto folder = (Windows::Storage::StorageFolder::GetFolderFromPathAsync( ref new Platform::String(val_wstring(p)) ))->GetResults();
    auto results = folder->GetFilesAsync(Windows::Storage::Search::CommonFileQuery::DefaultQuery)->GetResults();
    for(int i=0;i<results->Size;i++)
       val_array_push(result,alloc_wstring(results->GetAt(i)->Path->Data()));
-
 #elif defined(NEKO_WINDOWS)
 	const wchar_t *path = val_wstring(p);
 	size_t len = wcslen(path);
@@ -574,8 +563,13 @@ static value sys_read_dir( value p) {
 	WIN32_FIND_DATAW d;
 	HANDLE handle;
 	buffer b;
+  #if defined(HX_WINRT) && !defined(_XBOX_ONE)
+	std::wstring tempWStr(path);
+	std::string searchPath(tempWStr.begin(), tempWStr.end());
+  #else
    wchar_t searchPath[ MAX_PATH + 4 ];
    memcpy(searchPath,path, len*sizeof(wchar_t));
+  #endif
 
 
 	if( len && path[len-1] != '/' && path[len-1] != '\\' )
@@ -586,7 +580,11 @@ static value sys_read_dir( value p) {
    searchPath[len] = '\0';
 
 	gc_enter_blocking();
+  #if defined(HX_WINRT) && !defined(_XBOX_ONE)
+	handle = FindFirstFileEx(searchPath.c_str(), FindExInfoStandard, &d, FindExSearchNameMatch, NULL, 0);
+  #else
 	handle = FindFirstFileW(searchPath,&d);
+  #endif
 	if( handle == INVALID_HANDLE_VALUE )
 	{
 		gc_exit_blocking();
@@ -636,11 +634,8 @@ static value sys_read_dir( value p) {
 	<doc>Return an absolute path from a relative one. The file or directory must exists</doc>
 **/
 static value file_full_path( value path ) {
-#ifdef HX_WINRT
-   Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
-   Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
-   Platform::String^ output = "Installed Location: " + installedLocation->Path;
-   return path;
+#if defined(HX_WINRT)
+	return path;
 #elif defined(NEKO_WINDOWS)
 	char buf[MAX_PATH+1];
 	val_check(path,string);
@@ -663,7 +658,7 @@ static value file_full_path( value path ) {
 	<doc>Return the path of the executable</doc>
 **/
 static value sys_exe_path() {
-#ifdef HX_WINRT
+#if defined(HX_WINRT) && defined(__cplusplus_winrt)
    Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
    Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
    return(alloc_wstring(installedLocation->Path->Data()));

--- a/src/Math.cpp
+++ b/src/Math.cpp
@@ -2,13 +2,14 @@
 #include <limits>
 #include <hxMath.h>
 
-
 #include <stdlib.h>
 #include <time.h>
-#ifndef HX_WINDOWS
+#if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
 #include <sys/time.h>
-#else
+#elif defined(HX_WINRT) && !defined(__cplusplus_winrt)
+#include <windows.h>
+#elif defined(HX_WINDOWS)
 #include <process.h>
 #endif
 
@@ -137,20 +138,29 @@ void Math_obj::__boot()
 {
    Static(Math_obj::__mClass) = hx::RegisterClass(HX_CSTRING("Math"),TCanCast<Math_obj>,sMathFields,sNone, &__CreateEmpty,0 , 0 );
 
-	unsigned int t;
-#ifdef HX_WINDOWS
-	t = clock();
-   #ifdef HX_WINRT
-	int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
+#if defined(HX_WINDOWS) || defined(__SNC__)
+   unsigned int t = clock();
+#elif defined(__unix__) || defined(__APPLE__)
+   struct timeval tv;
+   gettimeofday(&tv,0);
+   unsigned int t = tv.tv_sec * 1000000 + tv.tv_usec;
+#endif
+
+#if defined(HX_WINDOWS)
+  #if defined(HX_WINRT)
+   #if defined(__cplusplus_winrt)
+   int pid = Windows::Security::Cryptography::CryptographicBuffer::GenerateRandomNumber();
    #else
-	int pid = _getpid();
+   int pid = GetCurrentProcessId();
    #endif
+  #else
+   int pid = _getpid();
+  #endif
+#elif defined(__unix__) || defined(__APPLE__)
+   int pid = getpid();
 #else
-	int pid = getpid();
-	struct timeval tv;
-	gettimeofday(&tv,0);
-	t = tv.tv_sec * 1000000 + tv.tv_usec;
-#endif	
+   int pid = (int)&t; // As a last resort, rely on ASLR.
+#endif  
 
   srand(t ^ (pid | (pid << 16)));
   rand();

--- a/src/hx/Object.cpp
+++ b/src/hx/Object.cpp
@@ -10,7 +10,6 @@
 #ifdef _WIN32
 
 #include <windows.h>
-#include <time.h>
 // Stoopid windows ...
 #ifdef RegisterClass
 #undef RegisterClass
@@ -21,7 +20,6 @@
 
 #else
 
-#include <sys/time.h>
 #include <wchar.h>
 #ifndef EMSCRIPTEN
 typedef  int64_t  __int64;
@@ -48,7 +46,7 @@ Dynamic Object::__IField(int inFieldID)
 
 double Object::__INumField(int inFieldID)
 {
-	return __IField(inFieldID);
+   return __IField(inFieldID);
 }
 
 Dynamic *Object::__GetFieldMap() { return 0; }
@@ -113,7 +111,7 @@ class Object__scriptable : public hx::Object {
    typedef hx::Object super;
    typedef hx::Object __superString;
    HX_DEFINE_SCRIPTABLE(HX_ARR_LIST0);
-	HX_DEFINE_SCRIPTABLE_DYNAMIC;
+   HX_DEFINE_SCRIPTABLE_DYNAMIC;
 };
 
 hx::ScriptFunction Object::__script_construct;

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -3,11 +3,9 @@
 
 #ifdef HX_WINDOWS
 #include <windows.h>
-#include <stdio.h>
 #include <io.h>
-#else
+#elif defined(__unix__) || defined(__APPLE__)
 #include <sys/time.h>
-#include <stdio.h>
 #ifndef EMSCRIPTEN
 typedef int64_t __int64;
 #endif
@@ -28,6 +26,7 @@ extern "C" EXPORT_EXTRA void AppLogInternal(const char* pFunction, int lineNumbe
 #include <string>
 #include <vector>
 #include <map>
+#include <stdio.h>
 #include <time.h>
 
 
@@ -233,7 +232,6 @@ void __hxcpp_exit(int inExitCode)
    exit(inExitCode);
 }
 
-static double t0 = 0;
 double  __time_stamp()
 {
 #ifdef HX_WINDOWS
@@ -254,19 +252,21 @@ double  __time_stamp()
       if (period!=0)
          return (now-t0)*period;
    }
-
    return (double)clock() / ( (double)CLOCKS_PER_SEC);
-#else
+#elif defined(__unix__) || defined(__APPLE__)
+   static double t0 = 0;
    struct timeval tv;
    if( gettimeofday(&tv,0) )
       throw Dynamic("Could not get time");
    double t =  ( tv.tv_sec + ((double)tv.tv_usec) / 1000000.0 );
    if (t0==0) t0 = t;
    return t-t0;
+#else
+   return (double)clock() / ( (double)CLOCKS_PER_SEC);
 #endif
 }
 
-#if defined(HX_WINDOWS)
+#if defined(HX_WINDOWS) && !defined(HX_WINRT)
 
 /*
 ISWHITE and ParseCommandLine are based on the implementation of the 
@@ -448,8 +448,7 @@ Array<String> __get_args()
    #else
    #ifdef ANDROID
    // TODO: Get from java
-   #else // linux
-
+   #elif defined(__linux__)
    char buf[80];
    sprintf(buf, "/proc/%d/cmdline", getpid());
    FILE *cmd = fopen(buf,"rb");

--- a/src/hx/Thread.cpp
+++ b/src/hx/Thread.cpp
@@ -3,11 +3,6 @@
 #include <hx/Thread.h>
 #include <time.h>
 
-#ifdef HX_WINRT
-using namespace Windows::Foundation;
-using namespace Windows::System::Threading;
-#endif
-
 DECLARE_TLS_DATA(class hxThreadInfo, tlsCurrentThread);
 
 // g_threadInfoMutex allows atomic access to g_nextThreadNumber
@@ -281,25 +276,7 @@ Dynamic __hxcpp_thread_create(Dynamic inStart)
 	hx::GCPrepareMultiThreaded();
 	hx::EnterGCFreeZone();
 
-   #if defined(HX_WINRT)
-
-   bool ok = true;
-   try
-   {
-     auto workItemHandler = ref new WorkItemHandler([=](IAsyncAction^)
-        {
-            // Run the user callback.
-            hxThreadFunc(info);
-        }, Platform::CallbackContext::Any);
-
-      ThreadPool::RunAsync(workItemHandler, WorkItemPriority::Normal, WorkItemOptions::None);
-   }
-   catch (...)
-   {
-      ok = false;
-   }
-
-   #elif defined(HX_WINDOWS)
+   #ifdef HX_WINDOWS
       bool ok = _beginthreadex(0,0,hxThreadFunc,info,0,0) != 0;
    #else
       pthread_t result = 0;
@@ -477,12 +454,12 @@ public:
 
 	hx::InternalFinalizer *mFinalizer;
 
-	#ifdef HX_WINDOWS
+	#if defined(HX_WINDOWS) || defined(__SNC__)
 	double Now()
 	{
 		return (double)clock()/CLOCKS_PER_SEC;
 	}
-	#else
+	#elif defined(__unix__) || defined(__APPLE__)
 	double Now()
 	{
 		struct timeval tv;

--- a/src/hx/gc/GcCommon.cpp
+++ b/src/hx/gc/GcCommon.cpp
@@ -26,7 +26,7 @@ extern void __hxt_new_string(void* result, int size);
 
 namespace hx
 {
-#if defined(HX_MACOS) || defined(HX_WINDOWS) || defined(HX_LINUX)
+#if defined(HX_MACOS) || defined(HX_WINDOWS) || defined(HX_LINUX) || defined(__ORBIS__)
 int sgMinimumWorkingMemory       = 20*1024*1024;
 int sgMinimumFreeSpace           = 10*1024*1024;
 #else
@@ -44,7 +44,7 @@ int sgTargetFreeSpacePercentage  = 100;
 // Called internally before and GC operations
 void CommonInitAlloc()
 {
-   #ifndef HX_WINRT
+   #if !defined(HX_WINRT) && !defined(__SNC__) && !defined(__ORBIS__)
    const char *minimumWorking = getenv("HXCPP_MINIMUM_WORKING_MEMORY");
    if (minimumWorking)
    {
@@ -84,7 +84,7 @@ void *String::operator new( size_t inSize )
 
 void __hxcpp_collect(bool inMajor)
 {
-	hx::InternalCollect(inMajor,inMajor);
+   hx::InternalCollect(inMajor,inMajor);
 }
 
 
@@ -152,7 +152,7 @@ void *NewGCPrivate(void *inData,int inSize)
 
 void __hxcpp_enable(bool inEnable)
 {
-	hx::InternalEnableGC(inEnable);
+   hx::InternalEnableGC(inEnable);
 }
 
 void  __hxcpp_set_minimum_working_memory(int inBytes)

--- a/src/hx/gc/GcRegCapture.h
+++ b/src/hx/gc/GcRegCapture.h
@@ -10,7 +10,7 @@ namespace hx
 #define HXCPP_CAPTURE_x86
 #endif
 
-#if (defined(HX_MACOS) || defined(HX_WINDOWS)) && defined(HXCPP_M64)
+#if (defined(HX_MACOS) || (defined(HX_WINDOWS) && !defined(HX_WINRT)) || defined(_XBOX_ONE)) && defined(HXCPP_M64)
 #define HXCPP_CAPTURE_x64
 #endif
 

--- a/toolchain/msvc-toolchain.xml
+++ b/toolchain/msvc-toolchain.xml
@@ -7,10 +7,11 @@
 
 <set name="USE_PRECOMPILED_HEADERS" value="msvc" unless="NO_PRECOMPILED_HEADERS" />
 
+<set name="ABI" value="-MD" if="winrt static_link" unless="ABI"/>
 <set name="ABI" value="-MT" unless="ABI"/>
 <set name="C_ABI" value="${ABI}" />
 
-<set name="ABI" value="-ZW" if="winrt" />
+<set name="ABI" value="-ZW" if="winrt" unless="ABI"/>
 <set name="CPP_ABI" value="${ABI}" />
 
 <set name="XPOBJ" value="xp" if="HXCPP_WINXP_COMPAT" />
@@ -113,7 +114,7 @@
 <linker id="exe" exe="link.exe" if="winrt">
   <fromfile value="@"/>
   <flag value="-nologo"/>
-  <flag value="-machine:x86"/>
+  <flag value="-machine:${MACHINE}"/>
   <flag value="-debug" if="HXCPP_DEBUG_LINK"/>
   <flag value="-subsystem:windows" />
   <flag value="-MANIFEST:NO" />

--- a/toolchain/msvc-winrt-setup.bat
+++ b/toolchain/msvc-winrt-setup.bat
@@ -1,14 +1,12 @@
 setlocal enabledelayedexpansion
 @if exist "%VS140COMNTOOLS%\vsvars32.bat" (
-	@call "%VS140COMNTOOLS%\vsvars32.bat"
-		@set "INCLUDE=%ProgramFiles(x86)%\Windows Kits\10\Include;!INCLUDE!"
-		@set "PATH=%ProgramFiles(x86)%\Windows Kits\10\bin\x86;!PATH!"
-		@set "LIB=%ProgramFiles(x86)%\Windows Kits\10\Lib\10.0.10240.0\um\x86;!LIB!"
-		@set "LIBPATH=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\lib\store\references;!LIBPATH!"
-
-	@echo HXCPP_VARS
-	@set
-
-) else (
-	echo Warning: Could not find environment variables for Visual Studio 2015
+    @call "%VS140COMNTOOLS%\vsvars32.bat"
+        @set "INCLUDE=%WindowsSdkDir%Include;!INCLUDE!"
+        @set "PATH=%WindowsSdkDir%bin\x86;!PATH!"
+        @set "LIB=%WindowsSdkDir%Lib\%WindowsSDKLibVersion%um\x86;!LIB!"
+        @set "LIBPATH=%VS140COMNTOOLS%\..\..\VC\lib\store\references;!LIBPATH!"
+    @echo HXCPP_VARS
+    @set
+) else (   
+    echo Warning: Could not find environment variables for Visual Studio 2015
 )

--- a/toolchain/msvc-winrt64-setup.bat
+++ b/toolchain/msvc-winrt64-setup.bat
@@ -1,0 +1,13 @@
+setlocal enabledelayedexpansion
+@if exist "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat" (
+    @call "%VS140COMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
+        @set "INCLUDE=%WindowsSdkDir%Include;!INCLUDE!"
+        @set "PATH=%WindowsSdkDir%bin\x64;!PATH!"
+        @set "LIB=%WindowsSdkDir%Lib\%WindowsSDKLibVersion%um\x64;!LIB!"
+        @set "LIBPATH=%VS140COMNTOOLS%\..\..\VC\lib\store\references;!LIBPATH!"
+    @echo HXCPP_VARS
+    @set
+    @echo HXCPP_HACK_PDBSRV=1
+) else (
+    echo Warning: Could not find x64 environment variables for Visual Studio 2015
+)

--- a/tools/hxcpp/BuildTool.hx
+++ b/tools/hxcpp/BuildTool.hx
@@ -1381,7 +1381,7 @@ class BuildTool
             {
                defines.set("toolchain","msvc");
                if ( defines.exists("winrt") )
-                  defines.set("BINDIR",m64 ? "WinRTx64":"WinRTx86");
+                  defines.set("BINDIR",m64 ? "WinRT64":"WinRT");
             }
             else
             {

--- a/tools/hxcpp/Setup.hx
+++ b/tools/hxcpp/Setup.hx
@@ -500,8 +500,11 @@ class Setup
 
       if (detectMsvc)
       {
-         var extra = in64 ? "64" : "";
-         extra += isWinRT? "-winrt" : "";
+        var extra:String = "";
+        if( isWinRT )
+            extra += "-winrt";
+        if( in64 )
+            extra += "64";
          var xpCompat = false;
          if (ioDefines.exists("HXCPP_WINXP_COMPAT"))
          {


### PR DESCRIPTION
- WinRT 64 bit
- Automatically set latest installed Windows 10 SDK paths using
environment variables (tested with both older and newer SDKs )
-Deprecates WinRT 8.x
-Encapsulates WinRT "store-api" with __cplusplus_winrt to enable
compiling of native static libs.
-Set to compile native libs (MD ABI) as default when static linking.
-Use GetTickCount64() for WInRT instead of clock() (this function is not
available on WindowsXP).
- james4k: changed order in Lib.cpp
- james4k: console porting fixes in time functions
-some style fixes
- fix __hxcpp_dbg_checkedThrow to work with winrt